### PR TITLE
Add ACC max distance in meters

### DIFF
--- a/module_comm_msgs/msg/AdaptiveCruiseControlSettings.msg
+++ b/module_comm_msgs/msg/AdaptiveCruiseControlSettings.msg
@@ -22,6 +22,8 @@ float32 cipv_percent    # Where CIPV is relative to the maximum allowed distance
                         # 1.0 = the CIPV is at the maximum allowed distance
                         # The maximum allowed distance varies with speed
 
+float32 max_distance    # The distance corresponding to 1.0 percent (meters)
+
 # So if the driver wants to maintain the greatest separation behind the CIPV,
 # he can press the increase distance button over and over until the distance
 # set point reaches the maximum allowed distance.  If there are 5 allowed


### PR DESCRIPTION
Add ACC maximum distance in meters so that it can be displayed on shuttle GUI instead of just the 0 to 100% value on the existing highway autopilot GUI.  The old GUI had bars to represent the 5 different possible following distance, but they were treated as a percentage.  As the vehicle slows down the distances get shorter since less following distance is needed at lower speeds.  This change isn't reflected in the old GUI.  In the new shuttle one the car is show in a top down view with lines representing the 5 distances.  These distances to move as the vehicle slows up and down.