### PR TITLE
ROS1/ROS2 Hybrid Packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,9 +56,38 @@ jobs:
             catkin_test_results
     working_directory: ~/src
 
+  dashing:
+    docker:
+      - image: autonomoustuff/docker-builds:dashing-ros-base
+    steps:
+      - checkout
+      - run:
+          name: Set Up Container
+          command: |
+            apt-get update -qq
+            source `find /opt/ros -maxdepth 2 -name local_setup.bash | sort | head -1`
+            rosdep update
+            rosdep install --from-paths . --ignore-src -y
+            cd ..
+      - run:
+          name: Build
+          command: |
+            source `find /opt/ros -maxdepth 2 -name local_setup.bash | sort | head -1`
+            cd ..
+            colcon build
+      - run:
+          name: Run Tests
+          command: |
+            source `find /opt/ros -maxdepth 2 -name local_setup.bash | sort | head -1`
+            cd ..
+            colcon build
+            colcon test-result
+    working_directory: ~/src
+
 workflows:
   version: 2
   ros_build:
     jobs:
       - kinetic
       - melodic
+      - dashing

--- a/automotive_autonomy_msgs/CMakeLists.txt
+++ b/automotive_autonomy_msgs/CMakeLists.txt
@@ -1,4 +1,13 @@
-cmake_minimum_required(VERSION 2.8.3)
 project(automotive_autonomy_msgs)
-find_package(catkin REQUIRED)
-catkin_metapackage()
+
+set(ROS_VERSION $ENV{ROS_VERSION})
+
+if(${ROS_VERSION} EQUAL 1)
+  cmake_minimum_required(VERSION 2.8.3)
+  find_package(catkin REQUIRED)
+  catkin_package()
+elseif(${ROS_VERSION} EQUAL 2)
+  cmake_minimum_required(VERSION 3.5)
+  find_package(ament_cmake REQUIRED)
+  ament_package()
+endif()

--- a/automotive_autonomy_msgs/package.xml
+++ b/automotive_autonomy_msgs/package.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>automotive_autonomy_msgs</name>
   <version>2.0.3</version>
   <description>Messages for vehicle automation</description>
@@ -13,12 +14,14 @@
   <author email="dstanek@autonomoustuff.com">Daniel Stanek</author>
   <author email="jwhitley@autonomoustuff.com">Joshua Whitley</author>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
 
   <exec_depend>automotive_navigation_msgs</exec_depend>
   <exec_depend>automotive_platform_msgs</exec_depend>
 
   <export>
-    <metapackage />
+    <build_type condition="$ROS_VERSION == 1">catkin</build_type>
+    <build_type condition="$ROS_VERSION == 2">ament_cmake</build_type>
   </export>
 </package>

--- a/automotive_autonomy_msgs/package.xml
+++ b/automotive_autonomy_msgs/package.xml
@@ -4,13 +4,11 @@
   <name>automotive_autonomy_msgs</name>
   <version>2.0.3</version>
   <description>Messages for vehicle automation</description>
+  <maintainer email="software@autonomoustuff.com">AutonomouStuff Software Development Team</maintainer>
   <license>MIT</license>
-
   <url type="website">http://github.com/automotive_autonomy_msgs</url>
   <url type="repository">https://github.com/astuff/automotive_autonomy_msgs</url>
   <url type="bugtracker">https://github.com/astuff/automotive_autonomy_msgs/issues</url>
-
-  <maintainer email="software@autonomoustuff.com">AutonomouStuff Software Development Team</maintainer>
   <author email="dstanek@autonomoustuff.com">Daniel Stanek</author>
   <author email="jwhitley@autonomoustuff.com">Joshua Whitley</author>
 

--- a/automotive_navigation_msgs/CMakeLists.txt
+++ b/automotive_navigation_msgs/CMakeLists.txt
@@ -1,41 +1,96 @@
-cmake_minimum_required(VERSION 2.8.3)
 project(automotive_navigation_msgs)
 
-find_package(catkin REQUIRED
-  COMPONENTS
-  message_generation
-  std_msgs
-  geometry_msgs
+set(ROS_VERSION $ENV{ROS_VERSION})
+
+set(MSG_FILES
+  "CommandWithHandshake.msg"
+  "DesiredDestination.msg"
+  "Direction.msg"
+  "DistanceToDestination.msg"
+  "LaneBoundary.msg"
+  "LaneBoundaryArray.msg"
+  "ModuleState.msg"
+  "PointOfInterestArray.msg"
+  "PointOfInterest.msg"
+  "PointOfInterestRequest.msg"
+  "PointOfInterestResponse.msg"
+  "PointOfInterestStatus.msg"
+  "RoadNetworkBoundaries.msg"
 )
 
-## Declare ROS messages and services
-add_message_files(DIRECTORY msg FILES
-  CommandWithHandshake.msg
-  DesiredDestination.msg
-  Direction.msg
-  DistanceToDestination.msg
-  LaneBoundary.msg
-  LaneBoundaryArray.msg
-  ModuleState.msg
-  PointOfInterestArray.msg
-  PointOfInterest.msg
-  PointOfInterestRequest.msg
-  PointOfInterestResponse.msg
-  PointOfInterestStatus.msg
-  RoadNetworkBoundaries.msg
-)
+if(${ROS_VERSION} EQUAL 1)
 
-add_service_files(DIRECTORY srv FILES
-  GetImageForMapTile.srv
-)
+  cmake_minimum_required(VERSION 2.8.3)
 
-## Generate added messages and services
-generate_messages(DEPENDENCIES std_msgs geometry_msgs)
+  find_package(catkin REQUIRED
+    COMPONENTS
+    message_generation
+    std_msgs
+    geometry_msgs
+  )
 
-## Declare a catkin package
-catkin_package(CATKIN_DEPENDS
-  message_runtime
-  std_msgs
-  geometry_msgs
-)
+  ## Declare ROS messages and services
+  add_message_files(DIRECTORY msg FILES
+    ${MSG_FILES}
+    DIRECTORY msg
+  )
 
+  add_service_files(DIRECTORY srv FILES
+    GetImageForMapTile.srv
+  )
+
+  ## Generate added messages and services
+  generate_messages(DEPENDENCIES std_msgs geometry_msgs)
+
+  ## Declare a catkin package
+  catkin_package(CATKIN_DEPENDS
+    message_runtime
+    std_msgs
+    geometry_msgs
+  )
+
+elseif(${ROS_VERSION} EQUAL 2)
+
+  cmake_minimum_required(VERSION 3.5)
+
+  if(NOT CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+    set(CMAKE_CXX_STANDARD 14)
+  endif()
+
+  if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    add_compile_options(-Wall -Wextra -Wpedantic)
+  endif()
+
+  find_package(ament_cmake REQUIRED)
+  find_package(builtin_interfaces REQUIRED)
+  find_package(geometry_msgs REQUIRED)
+  find_package(std_msgs REQUIRED)
+  find_package(rosidl_default_generators REQUIRED)
+
+  # Apend "msg/" to each file name
+  set(TEMP_LIST "")
+  foreach(MSG_FILE ${MSG_FILES})
+    list(APPEND TEMP_LIST "msg/${MSG_FILE}")
+  endforeach()
+  set(MSG_FILES ${TEMP_LIST})
+
+  rosidl_generate_interfaces(${PROJECT_NAME}
+    ${MSG_FILES}
+    DEPENDENCIES
+      builtin_interfaces
+      geometry_msgs
+      std_msgs
+    ADD_LINTER_TESTS
+  )
+
+  ament_export_dependencies(rosidl_default_runtime)
+
+  if(BUILD_TESTING)
+    find_package(ament_lint_auto REQUIRED)
+    ament_lint_auto_find_test_dependencies()
+  endif()
+
+  ament_package()
+
+endif()

--- a/automotive_navigation_msgs/migration/PointOfInterestRequest.bmr
+++ b/automotive_navigation_msgs/migration/PointOfInterestRequest.bmr
@@ -1,0 +1,103 @@
+class update_automotive_navigation_msgs_PointOfInterestRequest_32ddedb83d8866a4c42724a85ecf2c80(MessageUpdateRule):
+	old_type = "automotive_navigation_msgs/PointOfInterestRequest"
+	old_full_text = """
+# Point of Interest Request Message
+# Contains information needed to request point of interest information
+
+std_msgs/Header header
+
+string name        # Name of the point of interest list
+
+string module_name # module name of the requesting node
+
+uint16 requestId   # Unique id of this request
+                   # Can make another request with the same requestId and
+                   # different update_num, guid, or tolerance.  New one will
+                   # replace the old one.
+
+uint16 cancel      # Set to 1 to cancel the request with this requestId
+
+uint16 update_num  # The update number of the point list to use
+
+uint16 guid_valid  # Request is for a specific point, not all points in list
+uint64 guid        # The unique Id for the desired point
+
+float32 tolerance  # How close to the current vehicle's position a point needs to be
+
+
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data 
+# in a particular coordinate frame.
+# 
+# sequence ID: consecutively increasing ID 
+uint32 seq
+#Two-integer timestamp that is expressed as:
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')
+# time-handling sugar is provided by the client library
+time stamp
+#Frame this data is associated with
+string frame_id
+"""
+
+	new_type = "automotive_navigation_msgs/PointOfInterestRequest"
+	new_full_text = """
+# Point of Interest Request Message
+# Contains information needed to request point of interest information
+
+std_msgs/Header header
+
+string name        # Name of the point of interest list
+
+string module_name # module name of the requesting node
+
+uint16 request_id  # Unique id of this request
+                   # Can make another request with the same requestId and
+                   # different update_num, guid, or tolerance.  New one will
+                   # replace the old one.
+
+uint16 cancel      # Set to 1 to cancel the request with this requestId
+
+uint16 update_num  # The update number of the point list to use
+
+uint16 guid_valid  # Request is for a specific point, not all points in list
+uint64 guid        # The unique Id for the desired point
+
+float32 tolerance  # How close to the current vehicle's position a point needs to be
+
+
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data 
+# in a particular coordinate frame.
+# 
+# sequence ID: consecutively increasing ID 
+uint32 seq
+#Two-integer timestamp that is expressed as:
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')
+# time-handling sugar is provided by the client library
+time stamp
+#Frame this data is associated with
+string frame_id
+"""
+
+	order = 0
+	migrated_types = [
+		("Header","Header"),]
+
+	valid = True
+
+	def update(self, old_msg, new_msg):
+		self.migrate(old_msg.header, new_msg.header)
+		new_msg.name = old_msg.name
+		new_msg.module_name = old_msg.module_name
+		new_msg.request_id = old_msg.requestId
+		new_msg.cancel = old_msg.cancel
+		new_msg.update_num = old_msg.update_num
+		new_msg.guid_valid = old_msg.guid_valid
+		new_msg.guid = old_msg.guid
+		new_msg.tolerance = old_msg.tolerance

--- a/automotive_navigation_msgs/migration/PointOfInterestResponse.bmr
+++ b/automotive_navigation_msgs/migration/PointOfInterestResponse.bmr
@@ -1,0 +1,111 @@
+class update_automotive_navigation_msgs_PointOfInterestResponse_358e8fda302368ac6d7d1b651933b309(MessageUpdateRule):
+	old_type = "automotive_navigation_msgs/PointOfInterestResponse"
+	old_full_text = """
+# Point of Interest Response Message
+# Contains status information about the points within the threshold
+
+std_msgs/Header header
+
+string name             # Name of the point of interest list
+
+string module_name      # module name of the requesting node
+
+uint16 requestId        # Unique id of this request
+
+uint16 update_num       # The update number of the point list to use
+
+automotive_navigation_msgs/PointOfInterestStatus[] point_statuses # The status information
+
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data 
+# in a particular coordinate frame.
+# 
+# sequence ID: consecutively increasing ID 
+uint32 seq
+#Two-integer timestamp that is expressed as:
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')
+# time-handling sugar is provided by the client library
+time stamp
+#Frame this data is associated with
+string frame_id
+
+================================================================================
+MSG: automotive_navigation_msgs/PointOfInterestStatus
+# Point of Interest Status Message
+# Contains the distance, heading, a localized position of a point of interest
+
+uint64 guid        # Unique Id for this point
+
+float32 distance   # Great circle distance (meters)
+float32 heading    # Heading (radians)
+float32 x_position # Distance in front of the vehicle (meters)
+float32 y_position # Distance to the left of the vehicle (meters)
+
+string params      # List of parameter:value pairs
+"""
+
+	new_type = "automotive_navigation_msgs/PointOfInterestResponse"
+	new_full_text = """
+# Point of Interest Response Message
+# Contains status information about the points within the threshold
+
+std_msgs/Header header
+
+string name             # Name of the point of interest list
+
+string module_name      # module name of the requesting node
+
+uint16 request_id       # Unique id of this request
+
+uint16 update_num       # The update number of the point list to use
+
+automotive_navigation_msgs/PointOfInterestStatus[] point_statuses # The status information
+
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data 
+# in a particular coordinate frame.
+# 
+# sequence ID: consecutively increasing ID 
+uint32 seq
+#Two-integer timestamp that is expressed as:
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')
+# time-handling sugar is provided by the client library
+time stamp
+#Frame this data is associated with
+string frame_id
+
+================================================================================
+MSG: automotive_navigation_msgs/PointOfInterestStatus
+# Point of Interest Status Message
+# Contains the distance, heading, a localized position of a point of interest
+
+uint64 guid        # Unique Id for this point
+
+float32 distance   # Great circle distance (meters)
+float32 heading    # Heading (radians)
+float32 x_position # Distance in front of the vehicle (meters)
+float32 y_position # Distance to the left of the vehicle (meters)
+
+string params      # List of parameter:value pairs
+"""
+
+	order = 0
+	migrated_types = [
+		("Header","Header"),
+		("PointOfInterestStatus","PointOfInterestStatus"),]
+
+	valid = True
+
+	def update(self, old_msg, new_msg):
+		self.migrate(old_msg.header, new_msg.header)
+		new_msg.name = old_msg.name
+		new_msg.module_name = old_msg.module_name
+		new_msg.request_id = old_msg.requestId
+		new_msg.update_num = old_msg.update_num
+		self.migrate_array(old_msg.point_statuses, new_msg.point_statuses, "automotive_navigation_msgs/PointOfInterestStatus")

--- a/automotive_navigation_msgs/msg/DesiredDestination.msg
+++ b/automotive_navigation_msgs/msg/DesiredDestination.msg
@@ -1,7 +1,7 @@
 # Desired Destination Message
 # Contains the location of a desired destination
 
-Header header
+std_msgs/Header header
 
 uint8 msg_counter   # Increments each time a command is sent
                     # An acknowledge message should be published with this value

--- a/automotive_navigation_msgs/msg/Direction.msg
+++ b/automotive_navigation_msgs/msg/Direction.msg
@@ -1,5 +1,5 @@
 # Simple vehicle direction
-Header header
+std_msgs/Header header
 
 int8 BACKWARD=-1
 int8 ZERO=0

--- a/automotive_navigation_msgs/msg/DistanceToDestination.msg
+++ b/automotive_navigation_msgs/msg/DistanceToDestination.msg
@@ -1,7 +1,7 @@
 # Distance To Destination Message
 # Contains the distance to the desired destination
 
-Header header
+std_msgs/Header header
 
 uint8 msg_counter   # Increments each time a command is sent
                     # An acknowledge message should be published with this value

--- a/automotive_navigation_msgs/msg/PointOfInterestRequest.msg
+++ b/automotive_navigation_msgs/msg/PointOfInterestRequest.msg
@@ -7,7 +7,7 @@ string name        # Name of the point of interest list
 
 string module_name # module name of the requesting node
 
-uint16 requestId   # Unique id of this request
+uint16 request_id  # Unique id of this request
                    # Can make another request with the same requestId and
                    # different update_num, guid, or tolerance.  New one will
                    # replace the old one.

--- a/automotive_navigation_msgs/msg/PointOfInterestResponse.msg
+++ b/automotive_navigation_msgs/msg/PointOfInterestResponse.msg
@@ -7,7 +7,7 @@ string name             # Name of the point of interest list
 
 string module_name      # module name of the requesting node
 
-uint16 requestId        # Unique id of this request
+uint16 request_id       # Unique id of this request
 
 uint16 update_num       # The update number of the point list to use
 

--- a/automotive_navigation_msgs/package.xml
+++ b/automotive_navigation_msgs/package.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>automotive_navigation_msgs</name>
   <version>2.0.3</version>
   <description>Generic Messages for Navigation Objectives in Automotive Automation Software</description>
@@ -13,10 +14,27 @@
   <author email="dstanek@autonomoustuff.com">Daniel Stanek</author>
   <author email="jwhitley@autonomoustuff.com">Joshua Whitley</author>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
 
-  <build_depend>message_generation</build_depend>
-  <depend>std_msgs</depend>
+  <build_depend condition="$ROS_VERSION == 1">message_generation</build_depend>
+  <build_depend condition="$ROS_VERSION == 2">rosidl_default_generators</build_depend>
+
+  <depend condition="$ROS_VERSION == 1">rosbag_migration_rule</depend>
+  <depend condition="$ROS_VERSION == 2">builtin_interfaces</depend>
   <depend>geometry_msgs</depend>
-  <exec_depend>message_runtime</exec_depend>
+  <depend>std_msgs</depend>
+
+  <exec_depend condition="$ROS_VERSION == 1">message_runtime</exec_depend>
+  <exec_depend condition="$ROS_VERSION == 2">rosidl_default_runtime</exec_depend>
+
+  <test_depend condition="$ROS_VERSION == 2">ament_lint_auto</test_depend>
+  <test_depend condition="$ROS_VERSION == 2">ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type condition="$ROS_VERSION == 1">catkin</build_type>
+    <build_type condition="$ROS_VERSION == 2">ament_cmake</build_type>
+  </export>
 </package>

--- a/automotive_navigation_msgs/package.xml
+++ b/automotive_navigation_msgs/package.xml
@@ -34,5 +34,7 @@
   <export>
     <build_type condition="$ROS_VERSION == 1">catkin</build_type>
     <build_type condition="$ROS_VERSION == 2">ament_cmake</build_type>
+    <rosbag_migration_rule rule_file="migration/PointOfInterestRequest.bmr" />
+    <rosbag_migration_rule rule_file="migration/PointOfInterestResponse.bmr" />
   </export>
 </package>

--- a/automotive_navigation_msgs/package.xml
+++ b/automotive_navigation_msgs/package.xml
@@ -4,13 +4,11 @@
   <name>automotive_navigation_msgs</name>
   <version>2.0.3</version>
   <description>Generic Messages for Navigation Objectives in Automotive Automation Software</description>
+  <maintainer email="software@autonomoustuff.com">AutonomouStuff Software Development Team</maintainer>
   <license>MIT</license>
-
   <url type="website">http://github.com/automotive_navigation_msgs</url>
   <url type="repository">https://github.com/astuff/automotive_autonomy_msgs</url>
   <url type="bugtracker">https://github.com/astuff/automotive_autonomy_msgs/issues</url>
-
-  <maintainer email="software@autonomoustuff.com">AutonomouStuff Software Development Team</maintainer>
   <author email="dstanek@autonomoustuff.com">Daniel Stanek</author>
   <author email="jwhitley@autonomoustuff.com">Joshua Whitley</author>
 

--- a/automotive_platform_msgs/CMakeLists.txt
+++ b/automotive_platform_msgs/CMakeLists.txt
@@ -1,50 +1,100 @@
-cmake_minimum_required(VERSION 2.8.3)
 project(automotive_platform_msgs)
 
-find_package(catkin REQUIRED
-  COMPONENTS
-  message_generation
-  std_msgs
+set(ROS_VERSION $ENV{ROS_VERSION})
+
+set(MSG_FILES
+  "AdaptiveCruiseControlCommand.msg"
+  "AdaptiveCruiseControlSettings.msg"
+  "BlindSpotIndicators.msg"
+  "BrakeCommand.msg"
+  "BrakeFeedback.msg"
+  "CabinReport.msg"
+  "CurvatureFeedback.msg"
+  "DriverCommands.msg"
+  "GearCommand.msg"
+  "GearFeedback.msg"
+  "Gear.msg"
+  "HillStartAssist.msg"
+  "SpeedPedals.msg"
+  "SpeedMode.msg"
+  "Speed.msg"
+  "SteeringCommand.msg"
+  "Steer.msg"
+  "SteeringFeedback.msg"
+  "SteerMode.msg"
+  "SteerWheel.msg"
+  "ThrottleCommand.msg"
+  "ThrottleFeedback.msg"
+  "TurnSignalCommand.msg"
+  "UserInputADAS.msg"
+  "UserInputMedia.msg"
+  "UserInputMenus.msg"
+  "VelocityAccel.msg"
+  "VelocityAccelCov.msg"
 )
 
-## Declare ROS messages and services
-add_message_files(DIRECTORY msg FILES
-  AdaptiveCruiseControlCommand.msg
-  AdaptiveCruiseControlSettings.msg
-  BlindSpotIndicators.msg
-  BrakeCommand.msg
-  BrakeFeedback.msg
-  CabinReport.msg
-  CurvatureFeedback.msg
-  DriverCommands.msg
-  GearCommand.msg
-  GearFeedback.msg
-  Gear.msg
-  HillStartAssist.msg
-  SpeedPedals.msg
-  SpeedMode.msg
-  Speed.msg
-  SteeringCommand.msg
-  Steer.msg
-  SteeringFeedback.msg
-  SteerMode.msg
-  SteerWheel.msg
-  ThrottleCommand.msg
-  ThrottleFeedback.msg
-  TurnSignalCommand.msg
-  UserInputADAS.msg
-  UserInputMedia.msg
-  UserInputMenus.msg
-  VelocityAccel.msg
-  VelocityAccelCov.msg
-)
+if(${ROS_VERSION} EQUAL 1)
+  cmake_minimum_required(VERSION 2.8.3)
 
-## Generate added messages and services
-generate_messages(DEPENDENCIES std_msgs)
+  # Default to C++11
+  if(NOT CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 11)
+  endif()
 
-## Declare a catkin package
-catkin_package(CATKIN_DEPENDS
-  message_runtime
-  std_msgs
-)
+  find_package(catkin REQUIRED
+    COMPONENTS
+    message_generation
+    std_msgs
+  )
 
+  add_message_files(FILES
+    ${MSG_FILES}
+    DIRECTORY msg
+  )
+
+  generate_messages(DEPENDENCIES std_msgs)
+
+  ## Declare a catkin package
+  catkin_package(CATKIN_DEPENDS message_runtime)
+
+elseif(${ROS_VERSION} EQUAL 2)
+
+  cmake_minimum_required(VERSION 3.5)
+
+  if(NOT CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+    set(CMAKE_CXX_STANDARD 14)
+  endif()
+
+  if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    add_compile_options(-Wall -Wextra -Wpedantic)
+  endif()
+
+  find_package(ament_cmake REQUIRED)
+  find_package(builtin_interfaces REQUIRED)
+  find_package(std_msgs REQUIRED)
+  find_package(rosidl_default_generators REQUIRED)
+
+  # Apend "msg/" to each file name
+  set(TEMP_LIST "")
+  foreach(MSG_FILE ${MSG_FILES})
+    list(APPEND TEMP_LIST "msg/${MSG_FILE}")
+  endforeach()
+  set(MSG_FILES ${TEMP_LIST})
+
+  rosidl_generate_interfaces(${PROJECT_NAME}
+    ${MSG_FILES}
+    DEPENDENCIES builtin_interfaces std_msgs
+    ADD_LINTER_TESTS
+  )
+
+  ament_export_dependencies(rosidl_default_runtime)
+
+  if(BUILD_TESTING)
+    find_package(ament_lint_auto REQUIRED)
+    ament_lint_auto_find_test_dependencies()
+  endif()
+
+  ament_package()
+
+endif()

--- a/automotive_platform_msgs/msg/AdaptiveCruiseControlCommand.msg
+++ b/automotive_platform_msgs/msg/AdaptiveCruiseControlCommand.msg
@@ -1,7 +1,7 @@
 # Adaptive Cruise Control Command Message
 # Contains commands to engage/disengage ACC or adjust the set points
 
-Header header
+std_msgs/Header header
 
 uint8 msg_counter   # Increments each time a command is sent
                     # An acknowledge message should be published with this value

--- a/automotive_platform_msgs/msg/AdaptiveCruiseControlSettings.msg
+++ b/automotive_platform_msgs/msg/AdaptiveCruiseControlSettings.msg
@@ -1,7 +1,7 @@
 # Adaptive Cruise Control Settings Message
 # Contains the current settings/status of ACC
 
-Header header
+std_msgs/Header header
 
 float32 set_speed       # Current speed set point (m/sec)
 

--- a/automotive_platform_msgs/msg/CabinReport.msg
+++ b/automotive_platform_msgs/msg/CabinReport.msg
@@ -1,5 +1,5 @@
 # Status of vehicle cabin sensors
-Header header
+std_msgs/Header header
 
 # The door positions below are from the point of view of someone sitting
 # in the vehicle, facing the X positive direction. Not using driver/passenger

--- a/automotive_platform_msgs/msg/UserInputADAS.msg
+++ b/automotive_platform_msgs/msg/UserInputADAS.msg
@@ -1,5 +1,5 @@
 # User input (e.g. button presses) related to the factory ADAS functions
-Header header
+std_msgs/Header header
 
 bool btn_cc_on          # Cruise Control on
 bool btn_cc_off         # Cruise Control off

--- a/automotive_platform_msgs/msg/UserInputMedia.msg
+++ b/automotive_platform_msgs/msg/UserInputMedia.msg
@@ -1,5 +1,5 @@
 # User input (e.g. button presses) related to media controls
-Header header
+std_msgs/Header header
 
 bool btn_vol_up
 bool btn_vol_down

--- a/automotive_platform_msgs/msg/UserInputMenus.msg
+++ b/automotive_platform_msgs/msg/UserInputMenus.msg
@@ -1,5 +1,5 @@
 # Inputs (e.g. button presses) for in-vehicle menus
-Header header
+std_msgs/Header header
 
 bool str_whl_left_btn_left
 bool str_whl_left_btn_down

--- a/automotive_platform_msgs/package.xml
+++ b/automotive_platform_msgs/package.xml
@@ -4,13 +4,11 @@
   <name>automotive_platform_msgs</name>
   <version>2.0.3</version>
   <description>Generic Messages for Communication with an Automotive Autonomous Platform</description>
+  <maintainer email="software@autonomoustuff.com">AutonomouStuff Software Development Team</maintainer>
   <license>MIT</license>
-
   <url type="website">http://github.com/automotive_platform_msgs</url>
   <url type="repository">https://github.com/astuff/automotive_autonomy_msgs</url>
   <url type="bugtracker">https://github.com/astuff/automotive_autonomy_msgs/issues</url>
-
-  <maintainer email="software@autonomoustuff.com">AutonomouStuff Software Development Team</maintainer>
   <author email="dstanek@autonomoustuff.com">Daniel Stanek</author>
   <author email="jwhitley@autonomoustuff.com">Josh Whitley</author>
 

--- a/automotive_platform_msgs/package.xml
+++ b/automotive_platform_msgs/package.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>automotive_platform_msgs</name>
   <version>2.0.3</version>
   <description>Generic Messages for Communication with an Automotive Autonomous Platform</description>
@@ -13,9 +14,25 @@
   <author email="dstanek@autonomoustuff.com">Daniel Stanek</author>
   <author email="jwhitley@autonomoustuff.com">Josh Whitley</author>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
 
-  <build_depend>message_generation</build_depend>
+  <build_depend condition="$ROS_VERSION == 1">message_generation</build_depend>
+  <build_depend condition="$ROS_VERSION == 2">rosidl_default_generators</build_depend>
+
+  <depend condition="$ROS_VERSION == 2">builtin_interfaces</depend>
   <depend>std_msgs</depend>
-  <exec_depend>message_runtime</exec_depend>
+
+  <exec_depend condition="$ROS_VERSION == 1">message_runtime</exec_depend>
+  <exec_depend condition="$ROS_VERSION == 2">rosidl_default_runtime</exec_depend>
+
+  <test_depend condition="$ROS_VERSION == 2">ament_lint_auto</test_depend>
+  <test_depend condition="$ROS_VERSION == 2">ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type condition="$ROS_VERSION == 1">catkin</build_type>
+    <build_type condition="$ROS_VERSION == 2">ament_cmake</build_type>
+  </export>
 </package>


### PR DESCRIPTION
This PR migrates all message packages in this repo to ROS1/ROS2 hybrid packages. The only substantive change is `PointOfInterestRequest.requestId` to `PointOfInterestRequest.request_id` and the same for `PointOfInterestResponse.requestId` to `PointOfInterestResponse.request_id`. Migration rules were created to update these messages.

@Daniel-Stanek - Please let me know which (if any) packages need to be updated to accommodate this change.