### PR TITLE
Fix website URL

### DIFF
--- a/automotive_autonomy_msgs/package.xml
+++ b/automotive_autonomy_msgs/package.xml
@@ -6,7 +6,7 @@
   <description>Messages for vehicle automation</description>
   <maintainer email="software@autonomoustuff.com">AutonomouStuff Software Development Team</maintainer>
   <license>MIT</license>
-  <url type="website">http://github.com/automotive_autonomy_msgs</url>
+  <url type="website">http://github.com/astuff/automotive_autonomy_msgs</url>
   <url type="repository">https://github.com/astuff/automotive_autonomy_msgs</url>
   <url type="bugtracker">https://github.com/astuff/automotive_autonomy_msgs/issues</url>
   <author email="dstanek@autonomoustuff.com">Daniel Stanek</author>

--- a/automotive_navigation_msgs/package.xml
+++ b/automotive_navigation_msgs/package.xml
@@ -6,7 +6,7 @@
   <description>Generic Messages for Navigation Objectives in Automotive Automation Software</description>
   <maintainer email="software@autonomoustuff.com">AutonomouStuff Software Development Team</maintainer>
   <license>MIT</license>
-  <url type="website">http://github.com/automotive_navigation_msgs</url>
+  <url type="website">http://github.com/astuff/automotive_navigation_msgs</url>
   <url type="repository">https://github.com/astuff/automotive_autonomy_msgs</url>
   <url type="bugtracker">https://github.com/astuff/automotive_autonomy_msgs/issues</url>
   <author email="dstanek@autonomoustuff.com">Daniel Stanek</author>

--- a/automotive_platform_msgs/package.xml
+++ b/automotive_platform_msgs/package.xml
@@ -6,7 +6,7 @@
   <description>Generic Messages for Communication with an Automotive Autonomous Platform</description>
   <maintainer email="software@autonomoustuff.com">AutonomouStuff Software Development Team</maintainer>
   <license>MIT</license>
-  <url type="website">http://github.com/automotive_platform_msgs</url>
+  <url type="website">http://github.com/astuff/automotive_platform_msgs</url>
   <url type="repository">https://github.com/astuff/automotive_autonomy_msgs</url>
   <url type="bugtracker">https://github.com/astuff/automotive_autonomy_msgs/issues</url>
   <author email="dstanek@autonomoustuff.com">Daniel Stanek</author>


### PR DESCRIPTION
The URL is used by ROS infrastructure, for example to [direct users from the ROS index](https://index.ros.org/p/automotive_platform_msgs/github-astuff-automotive_autonomy_msgs/). The current URL results in a 404.